### PR TITLE
chore(deps): bump torch from 2.11.0+cpu to 2.12.0+cpu and torchvision from 0.26.0+cpu to 0.27.0+cpu in /docker/ai-panel

### DIFF
--- a/docker/ai-panel/requirements.txt
+++ b/docker/ai-panel/requirements.txt
@@ -2,8 +2,8 @@
 
 fastapi==0.136.1
 uvicorn==0.47.0
-torch==2.11.0+cpu
-torchvision==0.26.0+cpu
+torch==2.12.0+cpu
+torchvision==0.27.0+cpu
 ultralytics==8.4.51
 pillow==12.2.0
 numpy==2.4.6


### PR DESCRIPTION
Combined bump of torch and torchvision (they must be updated together due to tight version coupling).

- torch: 2.11.0+cpu → 2.12.0+cpu
- torchvision: 0.26.0+cpu → 0.27.0+cpu

Supersedes #90 and #71 which each failed independently due to the cross-dependency conflict.